### PR TITLE
Remove android.intent.action.SEND from manifest

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -138,11 +138,6 @@
             android:name=".activities.IntentActivity"
             android:theme="@style/Theme.Invisible">
             <intent-filter>
-                <action android:name="android.intent.action.SEND" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <data android:mimeType="text/plain" />
-            </intent-filter>
-            <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />


### PR DESCRIPTION
Removing the intent filter android.intent.action.SEND removes the app from Android's Share Menu, which is useful when the user doesn't want to make the apps presence obvious.